### PR TITLE
Add GtABContact#isCategory for the Tree demo view

### DIFF
--- a/src/GToolkit-Demo-AddressBook/GtABContact.class.st
+++ b/src/GToolkit-Demo-AddressBook/GtABContact.class.st
@@ -297,6 +297,11 @@ GtABContact >> initialize [
 ]
 
 { #category : #accessing }
+GtABContact >> isCategory [
+	^false
+]
+
+{ #category : #accessing }
 GtABContact >> lastName [
 	^ lastName
 ]


### PR DESCRIPTION
This fixes the disclosure triangle on the "tree" page of the Inspector Views presentation.