### PR TITLE
switch tour live doc example to lepiter

### DIFF
--- a/src/GToolkit-Demo-MoldableDevelopment/GtTour.class.st
+++ b/src/GToolkit-Demo-MoldableDevelopment/GtTour.class.st
@@ -509,7 +509,7 @@ GtTour >> liveDocumentExampleSlideFor: aSlide [
 	<gtSlide>
 	^ aSlide labelAndElement
 		priority: 28;
-		element: [ (GtDocumenter forClass: GtCSPicture) 
+		element: [ (LeCoderCommentElement coderElementFor: 'GtCSPicture') 
 			margin: (BlInsets all: 10);
 			background: Color white;
 			aptitude: BrShadowAptitude];


### PR DESCRIPTION
Right now the example is just showing markup; this is my guess at a fix.