### PR TITLE
website analysis demo

### DIFF
--- a/src/GToolkit-Demo-WebsiteExplorer/MarkdownWebLink.class.st
+++ b/src/GToolkit-Demo-WebsiteExplorer/MarkdownWebLink.class.st
@@ -4,6 +4,11 @@ Class {
 	#category : #'GToolkit-Demo-WebsiteExplorer-Model'
 }
 
+{ #category : #accessing }
+MarkdownWebLink >> path [
+^ super path replaceAllRegex: '\.md*#*(.*)' with: '.md'
+]
+
 { #category : #constant }
 MarkdownWebLink >> suffix [
 	"File suffix to be removed when generated the URL"

--- a/src/GToolkit-Demo-WebsiteExplorer/MarkdownWebLink.class.st
+++ b/src/GToolkit-Demo-WebsiteExplorer/MarkdownWebLink.class.st
@@ -5,6 +5,30 @@ Class {
 }
 
 { #category : #accessing }
+MarkdownWebLink >> checkPageStatus [
+	super checkPageStatus.
+	self status = self missingStatus ifFalse: [ ^ self ].
+	(self pageHeaderLinks includes: self headerName)
+		ifTrue: [ ^ self status: self okPageStatus ].
+	^ self
+]
+
+{ #category : #accessing }
+MarkdownWebLink >> headerName [
+	^ (self path copyFrom: (self path lastIndexOf: $/) + 1 to: self path size)
+		trimLeft: [ :char | char = $# or: [ char = Character space ] ]
+]
+
+{ #category : #accessing }
+MarkdownWebLink >> pageHeaderLinks [
+	| joinedSet |
+	joinedSet := Set new.
+	(self pages collect: [ :page | page headerLinks ])
+		do: [ :eachSet | joinedSet addAll: eachSet ].
+	^ joinedSet
+]
+
+{ #category : #accessing }
 MarkdownWebLink >> path [
 ^ super path replaceAllRegex: '\.md*#*(.*)' with: '.md'
 ]

--- a/src/GToolkit-Demo-WebsiteExplorer/MarkdownWebPage.class.st
+++ b/src/GToolkit-Demo-WebsiteExplorer/MarkdownWebPage.class.st
@@ -25,6 +25,21 @@ MarkdownWebPage >> gtMarkdownFor: aView [
 				snippetViewModel: snippetViewModel) vMatchParent ]
 ]
 
+{ #category : #accessing }
+MarkdownWebPage >> headerLinks [
+	^ self headers
+		collect: [ :header | 
+			(header asLowercase
+				trimBoth: [ :char | char = $# or: [ char isSeparator or: [ char = $` ] ] ])
+				copyReplaceAll: ' '
+				with: '-' ]
+]
+
+{ #category : #accessing }
+MarkdownWebPage >> headers [
+	^ (LeTextSnippet string: self contents) headers
+]
+
 { #category : #testing }
 MarkdownWebPage >> isRoot [
 "If the page's file has a YAML header, we can tell which page is the root."


### PR DESCRIPTION
Add the ability to link to headings of markdown pages.

This topic contains 2 different commits.

The first commit should be uncontroversial and does not rely on anything. And allows external links to a page's heading show up as not a missing link

the second commit is more questionable and allows linking to a header in the same page.

This relies upon:

https://github.com/feenkcom/lepiter/pull/9


being accepted as it relies on the header functions I made for it.