### PR TITLE
Fixing bug where die can continue being rolled even if it's a player's turn to move (and hence die element shouldn't respond to double clicks temporarily).

### DIFF
--- a/src/GToolkit-Demo-Ludo/GtLudoDieElement.class.st
+++ b/src/GToolkit-Demo-Ludo/GtLudoDieElement.class.st
@@ -17,7 +17,8 @@ Class {
 	#name : #GtLudoDieElement,
 	#superclass : #BlElement,
 	#instVars : [
-		'die'
+		'die',
+		'doubleClickHandler'
 	],
 	#category : #'GToolkit-Demo-Ludo-UI'
 }
@@ -46,6 +47,11 @@ GtLudoDieElement >> dieWidth [
 	^ 3 * self dotWidth + (4 * self dotSpace)
 ]
 
+{ #category : #'api - enablement' }
+GtLudoDieElement >> disable [
+	self removeEventHandler: doubleClickHandler
+]
+
 { #category : #constants }
 GtLudoDieElement >> dotSpace [
 	"Space between a dot and the edge of the die or another dot"
@@ -55,6 +61,11 @@ GtLudoDieElement >> dotSpace [
 { #category : #constants }
 GtLudoDieElement >> dotWidth [
 	^ 20
+]
+
+{ #category : #'api - enablement' }
+GtLudoDieElement >> enable [
+	self addEventHandler: doubleClickHandler
 ]
 
 { #category : #constants }
@@ -101,11 +112,12 @@ GtLudoDieElement >> initializeAnnouncements [
 		when: GtLudoDieRolled
 		send: #onRolled
 		to: self.
-	self
-		when: BlDoubleClickEvent
-		do: [ :anEvent | 
-			anEvent consumed: true.
-			self die roll ].
+	doubleClickHandler := BlEventHandler
+			on: BlDoubleClickEvent
+			do: [ :anEvent | 
+				anEvent consumed: true.
+				self die roll ].
+	self addEventHandler: doubleClickHandler.
 	self onRolled
 ]
 

--- a/src/GToolkit-Demo-Ludo/GtLudoGameElement.class.st
+++ b/src/GToolkit-Demo-Ludo/GtLudoGameElement.class.st
@@ -61,13 +61,11 @@ GtLudoGameElement >> initialize [
 GtLudoGameElement >> initializeFor: aGame [
 	game := aGame.
 	self
-		constraintsDo:
-			[ :c | 
+		constraintsDo: [ :c | 
 			c vertical fitContent.
 			c horizontal fitContent ].
 	self
-		addChild:
-			((aGame boardElement)
+		addChild: (aGame boardElement
 				addDieElement;
 				yourself).
 	self addChild: self feedbackElement.
@@ -75,7 +73,14 @@ GtLudoGameElement >> initializeFor: aGame [
 	game announcer
 		when: GtLudoBoardFeedbackUpdated
 		send: #onFeedbackUpdate
-		to: self
+		to: self.
+	game die announcer
+		when: GtLudoDieRolled
+		do: [ game playerToRoll ifFalse: [ (self query // GtLudoDieElement) anyOne disable ] ].
+	game announcer
+		when: GtLudoGameUpdated
+		do: [ (game isOver not and: [ game playerToRoll ])
+				ifTrue: [ (self query // GtLudoDieElement) anyOne enable ] ]
 ]
 
 { #category : #feedback }


### PR DESCRIPTION
Fixing bug where die can continue being rolled even if it's a player's turn to move (and hence die element shouldn't respond to double clicks temporarily).